### PR TITLE
[PARKED] Add DQ checks through deequ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ run-local:
 	source venv_dev/bin/activate && \
 	spark-submit \
 	--master local[*] \
-	--packages org.apache.spark:spark-avro_2.12:3.1.2,io.delta:delta-core_2.12:1.0.0 \
+	--packages org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:1.0.0,com.amazon.deequ:deequ:1.2.2-spark-3.0 \
+	--exclude-packages net.sourceforge.f2j:arpack_combined_all \
 	--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
 	--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
 	movies_etl/main.py \
@@ -52,7 +53,7 @@ run-cluster:
 	--master yarn \
 	--deploy-mode cluster \
 	--archives s3a://movies-binaries/movies-etl/latest/deps/venv_build.tar.gz#env \
-	--packages org.apache.spark:spark-avro_2.12:3.1.2,io.delta:delta-core_2.12:1.0.0 \
+	--packages org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:1.0.0 \
 	--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
 	--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
 	s3a://movies-binaries/movies-etl/latest/deps/main.py \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ run-local:
 	source venv_dev/bin/activate && \
 	spark-submit \
 	--master local[*] \
-	--packages org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:1.0.0,com.amazon.deequ:deequ:1.2.2-spark-3.0 \
+	--packages org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:0.8.0,com.amazon.deequ:deequ:1.2.2-spark-3.0 \
 	--exclude-packages net.sourceforge.f2j:arpack_combined_all \
 	--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
 	--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL=/bin/bash
+SPARK_VERSION=3.0.3
 
 help:
 	@echo  'Options:'

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ run-cluster:
 	--master yarn \
 	--deploy-mode cluster \
 	--archives s3a://movies-binaries/movies-etl/latest/deps/venv_build.tar.gz#env \
-	--packages org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:1.0.0 \
+	--packages org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:0.8.0,com.amazon.deequ:deequ:1.2.2-spark-3.0 \
+	--exclude-packages net.sourceforge.f2j:arpack_combined_all \
 	--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
 	--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
 	s3a://movies-binaries/movies-etl/latest/deps/main.py \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pyspark==3.0.3
-delta-spark==0.8.0
+delta-spark==1.0.0
 flake8==3.9.2
 mypy==0.910
 pytest==6.2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pyspark==3.1.2
+pyspark==3.0.3
 delta-spark==1.0.0
 flake8==3.9.2
 mypy==0.910

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pyspark==3.0.3
-delta-spark==1.0.0
+delta-spark==0.8.0
 flake8==3.9.2
 mypy==0.910
 pytest==6.2.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup, find_packages
 
 NAME = "movies-etl"
 VERSION = "0.0.1"
-REQUIRES = ["dynaconf==3.1.4"]
+REQUIRES = [
+    "dynaconf==3.1.4",
+    "pydeequ==1.0.1"
+]
 
 setup(
     name=NAME,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from pyspark.sql import DataFrame, SparkSession
 def get_local_spark() -> SparkSession:
     return (
         SparkSession.builder.master("local[*]")
-        .config("spark.jars.packages", "org.apache.spark:spark-avro_2.12:3.1.2,io.delta:delta-core_2.12:1.0.0")
+        .config("spark.jars.packages", "org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:1.0.0")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
         .getOrCreate()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from pyspark.sql import DataFrame, SparkSession
 def get_local_spark() -> SparkSession:
     return (
         SparkSession.builder.master("local[*]")
-        .config("spark.jars.packages", "org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:1.0.0")
+        .config("spark.jars.packages", "org.apache.spark:spark-avro_2.12:3.0.3,io.delta:delta-core_2.12:0.8.0")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
         .getOrCreate()


### PR DESCRIPTION
Add DQ checks through [deequ](https://github.com/awslabs/python-deequ).

Parked for the moment.
Deequ is not supported in Spark 3.1.2 yet. Older Spark 3 versions (3.0.3) have issues with Delta.