### PR TITLE
Simplify build and run process

### DIFF
--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -41,6 +41,9 @@ jobs:
       with:
         python-version: 3.9
 
+    - name: Install dependencies
+      run: make setup
+
     - name: Build application
       run: make build
 

--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -53,4 +53,4 @@ jobs:
     #     AWS_REGION: eu-west-1
     #     AWS_S3_BUCKET: movies-binaries
     #     SOURCE_DIR: deps
-    #     DEST_DIR: "spark-movies-etl/PR-${{ github.event.pull_request.number }}"
+    #     DEST_DIR: "movies-etl/PR-${{ github.event.pull_request.number }}"

--- a/.github/workflows/ci-cd-push.yml
+++ b/.github/workflows/ci-cd-push.yml
@@ -67,4 +67,4 @@ jobs:
     #     AWS_REGION: eu-west-1
     #     AWS_S3_BUCKET: movies-binaries
     #     SOURCE_DIR: deps
-    #     DEST_DIR: spark-movies-etl/latest
+    #     DEST_DIR: movies-etl/latest

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,9 @@ setup:
 	poetry install
 
 build:
-	rm -rf deps
-	mkdir deps
 	poetry build
 	poetry run pip install dist/*.whl -t libs
+	mkdir deps
 	cp movies_etl/main.py deps
 	poetry run python -m zipfile -c deps/libs.zip libs/*
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The logic is as follows:
 * On PR creation/update:
   * Run code checks and tests.
   * Build app **.
-  * Release to S3 (to a specific location for the PR, e.g. `s3://movies-binaries/spark-movies-etl/PR-123`).
+  * Release to S3 (to a specific location for the PR, e.g. `s3://movies-binaries/movies-etl/PR-123`).
 * On push to master:
   * Run code checks and tests.
   * Build app **.
-  * Release to S3 (to the location for the master version, e.g. `s3://movies-binaries/spark-movies-etl/latest`).
+  * Release to S3 (to the location for the master version, e.g. `s3://movies-binaries/movies-etl/latest`).
   * Create Github release.
 
 ** The app build contains the entrypoint + a zip containing the whole virtual env, so that all dependencies can be referenced when running the Spark job.


### PR DESCRIPTION
Simplify build and run process:
- Build deps with poetry and package them.
- Use `--py-files` to include them in `spark-submit` (instead of including venv).